### PR TITLE
Update Readme on BH Legacy to clarify current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ BloodHound Legacy has been replaced by the free BloodHound Community Edition:
 * [Installation instructions](https://bloodhound.specterops.io/get-started/quickstart/community-edition-quickstart)  
 * [Full documentation](https://bloodhound.specterops.io)  
 
+BloodHound was created by [@_wald0](https://www.twitter.com/_wald0), [@CptJesus](https://twitter.com/CptJesus), and [@harmj0y](https://twitter.com/harmj0y).
+
+BloodHound is maintained by the [BloodHound Enterprise](https://bloodhoundenterprise.io/) team.
+
 ## Access to Deprecated Resources
 
 You can still access the deprecated BloodHound Legacy documentation [here](https://bloodhound.readthedocs.io/en/latest/index.html).

--- a/README.md
+++ b/README.md
@@ -1,51 +1,27 @@
-# Latest Version of BloodHound Community Edition is Released
+# BloodHound Legacy Edition (v4) Has Been Deprecated
 
-For the latest version of BloodHound you may follow [this link to the BloodHound Community Edition repository](https://github.com/SpecterOps/BloodHound).
+This repository is for BloodHound Legacy (version 4), which was last updated in 2023 and is no longer maintained. It will be archived in the near future.
 
-## Deprecation Notice
+## Please Use the New BloodHound Community Edition
 
-This repository will be archived in the near future.
+BloodHound Legacy has been replaced by the free BloodHound Community Edition:  
+* [BloodHound Community Edition GitHub repository](https://github.com/SpecterOps/BloodHound)  
+* [Installation instructions](https://bloodhound.specterops.io/get-started/quickstart/community-edition-quickstart)  
+* [Full documentation](https://bloodhound.specterops.io)  
 
-<hr />
+## Access to Deprecated Resources
 
-[![Build](https://github.com/BloodHoundAD/BloodHound/actions/workflows/build.yml/badge.svg)](https://github.com/BloodHoundAD/BloodHound/actions/workflows/build.yml)
-[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/BloodHoundAD/BloodHound)](https://github.com/BloodHoundAD/BloodHound/releases/latest)
-![GitHub all releases](https://img.shields.io/github/downloads/BloodHoundAD/BloodHound/total)
-
-# Getting Started with BloodHound
-
-To get started with BloodHound, check out the [BloodHound docs.](https://bloodhound.readthedocs.io/en/latest/index.html)
-
-# About BloodHound
-
-BloodHound is a single page Javascript web application, built on top of [Linkurious](http://linkurio.us/), compiled with [Electron](http://electron.atom.io/), with a [Neo4j](https://neo4j.com/) database fed by a C# data collector.
-
-BloodHound uses graph theory to reveal the hidden and often unintended relationships within an Active Directory or Azure environment. Attackers can use BloodHound to easily identify highly complex attack paths that would otherwise be impossible to quickly identify. Defenders can use BloodHound to identify and eliminate those same attack paths. Both blue and red teams can use BloodHound to easily gain a deeper understanding of privilege relationships in an Active Directory or Azure environment.
-
-BloodHound was created by [@_wald0](https://www.twitter.com/_wald0), [@CptJesus](https://twitter.com/CptJesus), and [@harmj0y](https://twitter.com/harmj0y).
-
-BloodHound is maintained by the [BloodHound Enterprise](https://bloodhoundenterprise.io/) team.
+You can still access the deprecated BloodHound Legacy documentation [here](https://bloodhound.readthedocs.io/en/latest/index.html).
 
 # About BloodHound Enterprise
 
-[BloodHound Enterprise](https://bloodhoundenterprise.io/) is an Attack Path Management solution that continuously maps and quantifies Active Directory Attack Paths. You can remove millions, even billions of Attack Paths within your existing architecture and eliminate the attacker’s easiest, most reliable, and most attractive techniques.
-
-# Downloading BloodHound Binaries
-Pre-Compiled BloodHound binaries can be found [here](https://github.com/BloodHoundAD/BloodHound/releases). 
-
-The rolling release will always be updated to the most recent source. Tagged releases are considered "stable" but will likely not have new features or fixes.
-
-# Creating example data
-
-A sample database generator can be found [here](https://github.com/BloodHoundAD/BloodHound-Tools/tree/master/DBCreator)
-
-You can create your own example Active Directory environment using [BadBlood](https://github.com/davidprowe/BadBlood).
+[BloodHound Enterprise](https://specterops.io/bloodhound-overview/) is an Attack Path Management solution that continuously maps and quantifies Active Directory attack paths. It helps eliminate millions—even billions—of attack paths within your existing architecture, removing the attacker’s easiest, most reliable, and most attractive techniques.
 
 # License
 
 BloodHound uses graph theory to reveal hidden relationships and
 attack paths in an Active Directory environment.
-Copyright (C) 2016-2023 Specter Ops Inc.
+Copyright (C) 2016–2025 SpecterOps Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
To improve the user journey, the readme was updated to clarify that this version is deprecated and where to find the new resources (repo, docs). 