### PR TITLE
chore: BED-5823 Update setup-node to use v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup NodeJS
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: 16
         cache: npm


### PR DESCRIPTION
This PR updates the build action to use `setup-node@v4` to resolve the build-time failures. This is a result of deprecation of previous versions of the action. See https://github.com/actions/toolkit/discussions/1890 for reference.